### PR TITLE
Add CI/CD workflow and update version to 0.1.9 in Cargo files (#7)

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -54,6 +54,12 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Cache system dependencies
+        uses: awalsh128/cache-apt-pkgs-action@v1
+        with:
+          packages: wireguard-tools
+          version: 1.0
+
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
 


### PR DESCRIPTION
* Add CI/CD workflow and update version to 0.1.9 in Cargo files

* Remove CI and publish workflows from GitHub Actions

* Update CI/CD workflow and build script to use wireguard-tools
