### PR TITLE
Add CI/CD workflow and update version to 0.1.9 in Cargo files (#7)

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -72,6 +72,8 @@ jobs:
     if: github.ref_name == 'main' && github.event_name == 'push'
     runs-on: ubuntu-latest
     environment: production
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v6
 
@@ -83,6 +85,9 @@ jobs:
         with:
           packages: wireguard-tools
           version: 1.0
+
+      - name: Add musl target
+        run: rustup target add x86_64-unknown-linux-musl
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -991,7 +991,7 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wg-tui"
-version = "0.1.10"
+version = "0.1.12"
 dependencies = [
  "clap",
  "color-eyre",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wg-tui"
-version = "0.1.10"
+version = "0.1.12"
 edition = "2024"
 description = "A terminal user interface for managing WireGuard VPN tunnels"
 repository = "https://github.com/excoffierleonard/wg-tui"


### PR DESCRIPTION
* Add CI/CD workflow and update version to 0.1.9 in Cargo files

* Remove CI and publish workflows from GitHub Actions

* Update CI/CD workflow and build script to use wireguard-tools
